### PR TITLE
Add the Tabs tutorial video to Tabs section

### DIFF
--- a/gitkraken-client/interface.md
+++ b/gitkraken-client/interface.md
@@ -266,7 +266,7 @@ For a given vertical track, you can read from bottom to top, and right to left t
 ## Tabs
 
 <div class='embed-container embed-container--16-9'>
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/Wmjobrj0Qw?ecver=1" frameborder="0" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/QWmjobrj0Qw?ecver=1" frameborder="0" allowfullscreen></iframe>
 </div>
 
 ***


### PR DESCRIPTION
Hey Joey, I missed a character when copying the embed code and the current video errors on the page.

This should fix the issue.
