### PR TITLE
Add commit graph tutorial

### DIFF
--- a/gitkraken-client/interface.md
+++ b/gitkraken-client/interface.md
@@ -245,6 +245,11 @@ For deeper waters on staging, dive into [committing work](/working-with-commits/
 
 ***
 ## The Graph
+
+<div class='embed-container embed-container--16-9'>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/YWGpKPMALOs?ecver=1" frameborder="0" allowfullscreen></iframe>
+</div>
+
 Oooo <span style='color: #0669f7;'>c</span><span style='color: #8e00c2;'>o</span><span style='color: #c517b6;'>l</span><span style='color: #d90171;'>o</span><span style='color: #f25d2e;'>r</span><span style='color: #7bd938;'>s</span>!
 
 <img src='/wp-content/uploads/graph-gif.gif' class='figure img-floated img-floated--right'>


### PR DESCRIPTION
Adding the commit graph tutorial to /interface before the documentation section.