### PR TITLE
Add videos about themes, Left Panel, and GitLab Self Managed

### DIFF
--- a/gitkraken-client/gitlab-self-hosted.md
+++ b/gitkraken-client/gitlab-self-hosted.md
@@ -5,6 +5,9 @@ description: Easily integrate GitKraken with you GitLab Self-Managed repository.
 taxonomy:
     category: gitkraken-client
 
+<div class='embed-container embed-container--16-9'>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/BhIX7fGSM8k?ecver=1" frameborder="0" allowfullscreen></iframe>
+</div>
 ---
 
 GitKraken allows you to connect to GitLab Self-Managed (CE or EE), which will help you find repos when cloning or adding your remotes.

--- a/gitkraken-client/interface.md
+++ b/gitkraken-client/interface.md
@@ -118,6 +118,10 @@ In addition to Undo and Redo, the main toolbar houses common repo actions.
 ***
 ## Left reference panel
 
+<div class='embed-container embed-container--16-9'>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/4uSXlUUU0ds?ecver=1" frameborder="0" allowfullscreen></iframe>
+</div>
+
 Referred to as the left "ref" panel, GitKraken Client shows the properties below specific to your repository.
 
 * The panel and each section can be collapsed or expanded as needed. 

--- a/gitkraken-client/themes.md
+++ b/gitkraken-client/themes.md
@@ -5,6 +5,9 @@ description: Using and creating themes in GitKraken Client.
 taxonomy:
     category: gitkraken-client
 
+<div class='embed-container embed-container--16-9'>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/_TMprlLc740?ecver=1" frameborder="0" allowfullscreen></iframe>
+</div>
 ---
 
 ## Built-in Themes


### PR DESCRIPTION
Please double check how this looks for Themes, and GitLab Self Managed.

I placed the video files towards the top, but I'm unsure if it looks good.