### PR TITLE
Removes mention of only supporting Pageant

### DIFF
--- a/gitkraken-client/authentication.md
+++ b/gitkraken-client/authentication.md
@@ -110,8 +110,6 @@ This way, provided your keys are loaded, every action requiring a chat with your
 ### I'm having an SSH issue.
 Well if it's not working 100% of the time, the most common issues are:
 
-* SSH-agent on Windows &mdash; GitKraken Client currently only supports Pageant for the SSH agent for Windows.
- * You can download PuTTY and Pageant from their page <a href='http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html' target='_blank'>here</a>.
 * Misconfigured SSH settings &mdash; remote URL format
  * Check in <kbd><strong>Preferences > SSH</strong></kbd> to confirm that your SSH settings are correct.
  * Edit remotes in the left ref panel to ensure push and pull urls are set and in the correct format


### PR DESCRIPTION
I did a quick review of this page and did not see anything else outdated besides the following, which still may be partially true still. Should we leave this in for now until we fully migrate?
> * Expected use of SSH config &mdash; GitKraken Client does not currently respect your SSH config and cannot make use of any remote server nicknames or identities.
>     * You can either load your SSH key directly into GitKraken Client or use your system&rsquo;s SSH agent to authenticate with your remote.