### PR TITLE
Update license file paths for GitKraken client on Windows

### DIFF
--- a/gitkraken-client/current.md
+++ b/gitkraken-client/current.md
@@ -27,7 +27,7 @@ _“Lucario, use Focus Blast!”_
  - The new Focus View has improved to display all of your PRs, Issues, and WIPs.
    - You can access the new Focus View from the new Focus View tab. Note, the Focus View will no longer show within a Cloud Workspace.
    - You can still filter items by Workspace using the Workspace filter dropdown.
-- You can now host Cloud Patches on your own dedicated storage for the highest level of security (Requires an Enterprise plan).
+ - You can now host Cloud Patches on your own dedicated storage for the highest level of security (Requires an Enterprise plan).
    - Your organization's admin can configure a self-managed environment for your Cloud Patches at https://gitkraken.dev/settings/security.
    - When creating a Cloud Patch, GitKraken Client will display a message to confirm it will be securely stored on your organization's storage.
 

--- a/gitkraken-client/serverless.md
+++ b/gitkraken-client/serverless.md
@@ -127,13 +127,13 @@ You can also place your license file into specific directory locations for GitKr
 
 **Windows:**
 
-- ``C:\ProgramData\GitKraken``
+- `C:\\ProgramData\\GitKraken`
 
 - directory above the `exe`
 
 - directory of the `exe`
 
-- ``%APPDATA%\.gitkraken``
+- `%APPDATA%\\.gitkraken`
 
 #### Updating License file
 


### PR DESCRIPTION
The commit updates the license file paths for the GitKraken client on Windows. The new paths are:
- `C:\\ProgramData\\GitKraken`
- `%APPDATA%\\.gitkraken`

This change ensures that the license file is placed in the correct directory locations for GitKraken on Windows.
![image](https://github.com/gitkraken/gitkraken-client-docs/assets/84381718/8b8083cf-e181-40c3-ac78-f14d1282ae01)

